### PR TITLE
Fixed typo in fit method in tft_model.py

### DIFF
--- a/tft/libs/tft_model.py
+++ b/tft/libs/tft_model.py
@@ -1127,7 +1127,7 @@ class TemporalFusionTransformer(object):
       print('Using cached training data')
       train_data = TFTDataCache.get('train')
     else:
-      train_data = self._batch_data(valid_df)
+      train_data = self._batch_data(train_df)
 
     if valid_df is None:
       print('Using cached validation data')


### PR DESCRIPTION
The fit method in the TemporalFusionTransformer has typo which leads the model to use the `valid_df` as training and as validation set when the data has not been previously cached. This was fixed with this PR.